### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Full Decode Benchmark
 
 For benchmarking, only full decode method is used instead of lazy decoder. 
 
-Comparision were done on decoding same message 5000 times. 
+Comparison were done on decoding same message 5000 times. 
 See connexio.proto and run_google.py for test message and structure.
 
     Environment:


### PR DESCRIPTION
@connexio, I've corrected a typographical error in the documentation of the [cypb](https://github.com/connexio/cypb) project. Specifically, I've changed comparision to comparison. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
